### PR TITLE
docs: accurate contributing guide, review process, and community templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners for everything in the repository. Reviewers are requested
+# automatically from this list on every pull request. Keep this in sync with
+# the maintainer list in CONTRIBUTING.md.
+* @YuningQiu @258SusanLiu @ctao456 @GopeshKh @unrahul

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security issue
+    url: https://github.com/intel/gpu-ai-skills/blob/main/SECURITY.md
+    about: Please report security vulnerabilities through the process in SECURITY.md, not a public issue.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,25 @@
+name: Documentation issue
+description: A repository document is wrong, stale, or unclear.
+title: "[docs] <short summary>"
+labels: ["documentation"]
+body:
+  - type: input
+    id: file
+    attributes:
+      label: File
+      description: Which document, for example README.md or HOW_TO_TEST.md.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or unclear
+      description: Quote the passage if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-skill.yml
+++ b/.github/ISSUE_TEMPLATE/new-skill.yml
@@ -1,0 +1,45 @@
+name: New skill proposal
+description: Propose a new skill for the pack.
+title: "[skill] <proposed-skill-name>"
+labels: ["enhancement"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Proposed skill name
+      description: Kebab-case, matching the directory name it would live in.
+      placeholder: xpu-something-new
+    validations:
+      required: true
+  - type: dropdown
+    id: gate
+    attributes:
+      label: Which gate does it belong to
+      options:
+        - Run (get models on the GPU)
+        - Benchmark (measure performance)
+        - Profile (find bottlenecks)
+        - Tooling (estimation, planning, migration)
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What the skill does and when an agent should use it
+      description: This becomes the basis for the description frontmatter, so be specific about the trigger conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: coverage
+    attributes:
+      label: Why existing skills do not cover this
+      description: Name the closest existing skill and what it is missing.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: How claims will be verified
+      description: Public sources or an inline verify-locally recipe. Skills must not depend on internal resources.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/skill-bug.yml
+++ b/.github/ISSUE_TEMPLATE/skill-bug.yml
@@ -1,0 +1,60 @@
+name: Skill bug report
+description: A skill gives wrong instructions, a command fails, or a script misbehaves.
+title: "[bug] <skill-name>: <short summary>"
+labels: ["bug"]
+body:
+  - type: input
+    id: skill
+    attributes:
+      label: Skill
+      description: The skill directory name, for example vllm-xpu-run.
+      placeholder: vllm-xpu-run
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What the skill instructed, what you ran, and what went wrong. Paste the exact command and error output.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: dropdown
+    id: stack
+    attributes:
+      label: Stack
+      options:
+        - PyTorch + Transformers (torch.xpu)
+        - vLLM XPU
+        - SGLang XPU
+        - Tooling only (no model stack)
+    validations:
+      required: true
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU
+      description: For example Arc A770, Arc Pro B60, Data Center GPU Max 1100.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Driver and runtime details. Output of xpu-smi discovery, the container image and tag if used, and the host OS.
+      render: text
+    validations:
+      required: false
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: The Hugging Face model id involved, if any.
+      placeholder: Qwen/Qwen2.5-1.5B-Instruct
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## What changed and why
+
+<!-- Describe the change and the motivation. Link any related issue. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] New skill
+- [ ] Fix to an existing skill
+- [ ] Performance or accuracy improvement (include benchmark data below)
+- [ ] Docs or tooling
+
+## Validation
+
+- [ ] `bash scripts/check-skills.sh` passes locally
+- [ ] `python3 scripts/generate_agents.py` was run after any `SKILL.md`
+      frontmatter change (or the pre-commit hook handled it)
+- [ ] For skill behavior changes, the relevant acceptance layer in
+      `HOW_TO_TEST.md` was run on real hardware, or the reason it was not
+      is explained above
+- [ ] Every commit is signed off (`git commit -s`), per the Developer
+      Certificate of Origin in CONTRIBUTING.md
+
+## Benchmark data
+
+<!-- Required for performance claims. Delete this section otherwise. -->

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  static-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install gate dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+          python3 -m pip install libcst
+      - name: Run validation gate
+        run: bash scripts/check-skills.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ bash tests/static.sh
 # Run repo checker + external skill-validator (if installed)
 bash scripts/check-skills.sh
 
-# External validator (optional, brew-only)
-brew tap agent-ecosystem/tap && brew install skill-validator
+# External validator (optional)
+# install: https://github.com/agent-ecosystem/skill-validator
 ```
 
 The static gate validates:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,12 +124,9 @@ Two tools extend the gate's coverage and are worth installing:
 - `libcst` (`pip install libcst`): needed by the `xpu-port` regression
   test. Without it that test prints a `SKIP` notice and is not run.
 
-Install the external validator with Homebrew:
-
-```sh
-brew tap agent-ecosystem/tap
-brew install skill-validator
-```
+The external validator is
+[agent-ecosystem/skill-validator](https://github.com/agent-ecosystem/skill-validator);
+its README covers installation on any platform.
 
 To make the external validator mandatory instead of optional:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,32 @@
 # Contributing
 
-### License
+Thank you for your interest in improving Intel GPU AI Skills. This guide
+covers the license terms, the sign-off requirement, the branching workflow,
+the review process, and the validation gate every change must pass.
 
-Intel GPU AI Skills is licensed under the terms in [LICENSE](LICENSE). By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
+We welcome pull requests of these kinds:
 
-### Sign your work
+- **New skills**: a run, benchmark, profile, or tooling workflow for Intel
+  GPUs that the pack does not cover yet.
+- **Fixes to existing skills**: wrong flags, stale image or package
+  references, broken commands, missing edge cases.
+- **Performance and accuracy improvements**: better launch recipes or
+  configuration guidance, backed by numbers from the benchmark skills.
+- **Docs and tooling**: the validation gate, install script, templates,
+  and repository documentation.
 
-Please use the sign-off line at the end of the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. The rules are pretty simple: if you can certify
-the below (from [developercertificate.org](http://developercertificate.org/)):
+## License
+
+Intel GPU AI Skills is licensed under the terms in [LICENSE](LICENSE).
+By contributing to the project, you agree to the license and copyright terms
+therein and release your contribution under these terms.
+
+## Sign your work
+
+Please use the sign-off line at the end of each patch. Your signature
+certifies that you wrote the patch or otherwise have the right to pass it on
+as an open-source patch. The rules are simple: if you can certify the below
+(from [developercertificate.org](http://developercertificate.org/)):
 
 ```
 Developer Certificate of Origin
@@ -47,71 +66,92 @@ By making a contribution to this project, I certify that:
     this project or the open source license(s) involved.
 ```
 
-Then you just add a line to every git commit message:
+then add a line to every git commit message:
 
     Signed-off-by: Joe Smith <joe.smith@email.com>
 
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
+Use your real name. Pseudonyms and anonymous contributions are not accepted.
 
-If you set your `user.name` and `user.email` git configs, you can sign your
-commit automatically with `git commit -s`.
+If your `user.name` and `user.email` git configs are set, `git commit -s`
+adds the sign-off automatically.
 
-## Development workflow
+## Branching and pull requests
 
-Run the local checker before every skill change:
+All changes land through pull requests against `main`. Do not commit to
+`main` directly.
+
+1. Fork the repository, or clone it directly if you have write access.
+2. Create a topic branch from the tip of `main`. Use a short descriptive
+   name such as `fix/vllm-xpu-run-typo` or `skill/xpu-newthing`.
+3. Make your change. Keep each commit to one logical change and sign it off.
+4. Run the validation gate described below and make sure it passes.
+5. Push the branch and open a pull request against `main`. Explain what
+   changed and why, and link any related issue.
+6. Address review feedback with follow-up commits or a rebase. Rebase on
+   `main` rather than merging `main` into your branch.
+
+## Review process
+
+- Reviewers are requested automatically through `.github/CODEOWNERS`. You
+  can also request a review from any maintainer listed at the end of this
+  guide.
+- Open work in progress as a draft pull request. Mark it ready for review
+  once it is complete and the validation gate passes.
+- Simple changes need at least one maintainer approval before merging.
+- Complex changes, such as a new skill or a cross-cutting tooling change,
+  need at least two maintainer approvals.
+- All CI checks must pass. CI runs the same gate as
+  `bash scripts/check-skills.sh`, so a green local run means a green CI run.
+- When enabling something new, update the relevant tests, and include
+  benchmark data when claiming a performance improvement.
+
+## Validation gate
+
+Run the local checker before every change:
 
 ```sh
 bash scripts/check-skills.sh
 ```
 
-This runs the repo static gate and, when `skill-validator` is installed,
-the external Agent Skills validator.
+This runs the repo static gate (`bash tests/static.sh`) and, when
+`skill-validator` is installed, the external Agent Skills validator over
+every skill directory.
 
-The static checks are stdlib-only, but the guardrails step of this gate
-(`guardrails/check.py`) needs PyYAML, so install it once per environment:
+Two tools extend the gate's coverage and are worth installing:
 
-```sh
-python3 -m pip install pyyaml
-```
+- `ripgrep` (`rg`): the documentation and script pattern checks in
+  `tests/static.sh` depend on it.
+- `libcst` (`pip install libcst`): needed by the `xpu-port` regression
+  test. Without it that test prints a `SKIP` notice and is not run.
 
-Without it that step exits `PyYAML is required: pip install pyyaml` and the
-gate fails. See [Layer 1 in HOW_TO_TEST.md](HOW_TO_TEST.md#layer-1--static-checks-10-seconds-no-gpu)
-for the full prerequisite list.
-
-Install the external validator:
+Install the external validator with Homebrew:
 
 ```sh
 brew tap agent-ecosystem/tap
 brew install skill-validator
 ```
 
-To require the external validator, use:
+To make the external validator mandatory instead of optional:
 
 ```sh
 REQUIRE_SKILL_VALIDATOR=1 bash scripts/check-skills.sh
 ```
 
-The static gate needs PyYAML (frontmatter checks) and libcst (the `xpu-port`
-scan/rewrite regressions). Install both with `pip install pyyaml libcst`; a
-missing one is reported as a failure rather than a silent skip, so set
-`SKIP_OK=1` if you deliberately want to run without them.
-
 The repo static gate verifies:
 
 - JSON manifests parse
-- every `SKILL.md` has `name` and `description`
-- every `SKILL.md` frontmatter block parses as YAML (an unquoted colon in a
-  description makes the skill invisible to `npx skills` and other consumers —
-  quote the whole value when it contains `: `)
-- skill name matches its directory
-- Python helper scripts compile
-- shell scripts parse
-- `agents/AGENTS.md` matches the generator
+- every `SKILL.md` has `name` and `description` frontmatter, and the
+  `name` matches its directory
+- Python helper scripts compile and shell scripts parse
+- mocked integration checks pass for `xpu-runtime-preflight`,
+  `model-can-it-fit`, `xpu-port`, and skill routing
+- `agents/AGENTS.md` matches the generator output
+- every skill appears in `catalog/bundles.yaml`
 - Claude marketplace entries cover every skill
 - shipped docs do not reference internal scratch paths
 - shipped scripts avoid destructive cleanup patterns
-- docs do not advertise TODO command behavior
-- generated `agents/AGENTS.md` has stable markdown shape
+- docs do not advertise unimplemented command behavior
+- generated `agents/AGENTS.md` has a stable markdown shape
 
 The external validator checks Agent Skills structure, token size, internal
 links, content metrics, and cross-language contamination. The local wrapper
@@ -119,19 +159,24 @@ skips external link checks by default to avoid network flake in normal
 development and allows the pack's intentional `data/` support directory.
 
 Neither checker proves that an agent will choose the skill correctly or that
-the commands in the skill work on a real host. For that, run the relevant
-acceptance layer in `HOW_TO_TEST.md`.
+the commands in a skill work on a real host. For that, run the relevant
+acceptance layer in [HOW_TO_TEST.md](HOW_TO_TEST.md).
 
-When adding or updating a skill:
+## Adding or updating a skill
 
-- keep the directory name and `name` frontmatter identical
+- start from `template/SKILL.md`
+- keep the directory name and the `name` frontmatter identical
 - keep `description` specific about what the skill does and when to use it
+- quote the whole `description` value when it contains a colon followed by
+  a space; an unquoted colon breaks YAML parsing and makes the skill
+  invisible to consumers
 - keep `SKILL.md` focused; move bulky detail into supporting files
 - use public sources or inline local verification recipes
 - do not reference `research/` from shipped skills
-- avoid destructive commands such as `pkill`, `docker rm -f`, or broad `rm -rf`
-- add the new skill to `catalog/bundles.yaml` under the right category
-  (and any cross-cutting bundles it belongs to)
+- avoid destructive commands such as `pkill`, `docker rm -f`, or broad
+  `rm -rf`
+- add the new skill to `catalog/bundles.yaml` under the right category,
+  plus any cross-cutting bundles it belongs to
 - run `python3 scripts/generate_agents.py` after skill metadata changes
   (the pre-commit hook below does this automatically)
 - run `bash scripts/check-skills.sh` before commit
@@ -139,23 +184,56 @@ When adding or updating a skill:
 ## Pre-commit hook
 
 A local pre-commit hook keeps `agents/AGENTS.md` in sync with skill
-frontmatter so you don't have to remember to regenerate it. Install it
-once per clone:
+frontmatter so you do not have to remember to regenerate it. Install it once
+per clone:
 
 ```sh
 pip install pre-commit
 pre-commit install
 ```
 
-After that, every `git commit` runs `python3 scripts/generate_agents.py`
-and re-stages `agents/AGENTS.md` if it changed, so the refreshed bundle
-lands in the same commit. The hook runs unconditionally rather than
-filtering on `SKILL.md` paths so that staged skill *deletions* — which
-pre-commit's default path filter drops — still trigger a regeneration.
-When nothing skill-related changed, the generator is a no-op and adds
-no files to the commit.
+After that, every `git commit` runs `python3 scripts/generate_agents.py` and
+re-stages `agents/AGENTS.md` if it changed, so the refreshed bundle lands in
+the same commit. The hook always runs rather than filtering on `SKILL.md`
+paths, so staged skill deletions also trigger a regeneration. When nothing
+skill-related changed, the generator is a no-op and adds no files to the
+commit.
 
-If the hook ever blocks an emergency fix, `git commit --no-verify`
-bypasses it for that single commit. Use this only as an escape hatch
-and follow up with a normal commit that includes the regenerated
-`agents/AGENTS.md`; `bash tests/static.sh` will otherwise fail on drift.
+If the hook ever blocks an emergency fix, `git commit --no-verify` bypasses
+it for that single commit. Use this only as an escape hatch and follow up
+with a normal commit that includes the regenerated `agents/AGENTS.md`;
+`bash tests/static.sh` will otherwise fail on drift.
+
+## Maintainers and contributors
+
+Maintainers:
+
+- Yuning Qiu ([@YuningQiu](https://github.com/YuningQiu),
+  <yuning.qiu@intel.com>)
+- Susan Liu ([@258SusanLiu](https://github.com/258SusanLiu),
+  <susan1.liu@intel.com>)
+- Chun Tao ([@ctao456](https://github.com/ctao456),
+  <chun.tao@intel.com>)
+- Gopesh Khandelwal ([@GopeshKh](https://github.com/GopeshKh),
+  <gopesh.khandelwal@intel.com>)
+- Rahul Unnikrishnan Nair ([@unrahul](https://github.com/unrahul),
+  <rahul.unnikrishnan.nair@intel.com>)
+
+Contributors:
+
+- Jerry Zhang ([@inteljerry](https://github.com/inteljerry),
+  <jerry.zhang@intel.com>)
+- Akash Dhamasia ([@akashdhamasia12](https://github.com/akashdhamasia12),
+  <akash.dhamasia@intel.com>)
+- Min Sung Kim ([@mins2022](https://github.com/mins2022),
+  <min.sung.kim@intel.com>)
+- Gilliean Lee ([@gilliean](https://github.com/gilliean),
+  <gilliean.lee@intel.com>)
+- Kushal Mittal ([@kushal2705](https://github.com/kushal2705),
+  <kushal.mittal@intel.com>)
+- Vishnu V Ravi (<vishnu.v.ravi@intel.com>)
+- Zhiqi Tao ([@zhiqitao-intel](https://github.com/zhiqitao-intel),
+  <zhiqi.tao@intel.com>)
+- Dunni Aribuki (<dunni.aribuki@intel.com>)
+- Yogini Dandekar ([@yogit2020](https://github.com/yogit2020),
+  <yogini.dandekar@intel.com>)

--- a/HOW_TO_TEST.md
+++ b/HOW_TO_TEST.md
@@ -72,19 +72,11 @@ This validates:
 
 Expected output: `All checks passed.` Anything else is a bug.
 
-Every check above is stdlib-only, so on the release branch this layer runs on a
-bare interpreter. On `main` the gate additionally runs `guardrails/check.py`,
-which needs PyYAML; without it that step prints `PyYAML is required: pip install
-pyyaml` and the gate exits non-zero. On `main`, install it first:
+Every check above uses only the Python standard library, so this layer runs on
+a bare interpreter. The documentation and script pattern checks shell out to
+`ripgrep` (`rg`), so have it on your PATH.
 
-```sh
-python3 -m pip install pyyaml
-```
-
-It is not made a skip when absent on purpose — a missing package must not
-silently switch a gate off.
-
-One further optional package: `tests/xpu-port.sh` needs `libcst` to exercise its
+One optional package: `tests/xpu-port.sh` needs `libcst` to exercise its
 scanner and rewriter sections. Absent it, that script announces `SKIP: libcst not
 importable` and the rest of the suite still passes. `pip install libcst` if you
 are changing anything under the `xpu-port` skill.

--- a/scripts/check-skills.sh
+++ b/scripts/check-skills.sh
@@ -17,11 +17,11 @@ bash tests/static.sh
 if ! command -v skill-validator >/dev/null 2>&1; then
     if [ "${REQUIRE_SKILL_VALIDATOR:-0}" = 1 ]; then
         echo "skill-validator is required but is not installed" >&2
-        echo "install: brew tap agent-ecosystem/tap && brew install skill-validator" >&2
+        echo "install: https://github.com/agent-ecosystem/skill-validator" >&2
         exit 1
     fi
     echo "skill-validator not found; skipped external Agent Skills validation"
-    echo "install: brew tap agent-ecosystem/tap && brew install skill-validator"
+    echo "install: https://github.com/agent-ecosystem/skill-validator"
     exit 0
 fi
 


### PR DESCRIPTION
## What changed and why

**CONTRIBUTING.md (rewritten)**
- Removes the stale guardrails, PyYAML, and SKIP_OK claims; every remaining claim is verified against `tests/static.sh` and `scripts/check-skills.sh`
- Adds a fork and topic-branch pull request workflow
- Adds a review process: draft PRs, CODEOWNERS auto-assignment, one maintainer approval for simple changes and two for complex ones, green CI required
- Documents the real optional dependencies: ripgrep for the pattern checks, libcst for the xpu-port regressions
- Adds the maintainer and contributor lists with GitHub handles

**HOW_TO_TEST.md**
- Drops the stale guardrails and PyYAML prerequisite from Layer 1; notes the ripgrep dependency instead

**.github/ (new)**
- `CODEOWNERS`: the five maintainers as default owners, so reviewers are requested automatically
- `PULL_REQUEST_TEMPLATE.md`: change type, validation checklist, sign-off confirmation
- `ISSUE_TEMPLATE/`: skill bug report, new skill proposal, docs issue, and a security contact link to SECURITY.md
- `workflows/validate.yml`: runs `bash scripts/check-skills.sh` on pull requests and pushes to main

## Validation

- `bash scripts/check-skills.sh` passes locally
- All issue form and workflow YAML parses
- All GitHub handles in CODEOWNERS and CONTRIBUTING verified against live accounts
