### PR TITLE
Ctao/add formattter to agents md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ gemini extensions install . --consent
 gemini extensions install https://github.com/intel/gpu-ai-skills.git --consent
 ```
 
+> **Upgrading from an older install?** 
+>
+> Please uninstall it first. Clean out any existing installs before reinstalling:
+>
+> ```sh
+> gemini extensions list
+> gemini extensions uninstall intel-gpu-ai-skills     # current name, if present
+> rm -rf ~/.gemini/extensions/intel-gpu-ai-skills
+>
+> gemini extensions install . --consent
+> ```
+
 ### Clone / Copy
 
 For any other agent, clone this repo and copy the skill folders into the agent's skills directory:

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,8 +1,3 @@
----
-name: intel-gpu-ai-skills-agent
-description: Router agent exposing Intel GPU AI skill packs for running, benchmarking, and profiling Hugging Face models, and migrating workloads from CUDA on Intel GPUs.
----
-
 <skills>
 
 You have additional SKILLs documented in directories containing a "SKILL.md" file.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: intel-gpu-ai-skills-agent
+description: Router agent exposing Intel GPU AI skill packs for running, benchmarking, and profiling Hugging Face models, and migrating workloads from CUDA on Intel GPUs.
+---
+
 <skills>
 
 You have additional SKILLs documented in directories containing a "SKILL.md" file.

--- a/scripts/generate_agents.py
+++ b/scripts/generate_agents.py
@@ -62,6 +62,12 @@ def main() -> int:
 
     OUT.parent.mkdir(exist_ok=True)
     with OUT.open("w") as f:
+        f.write("---\n")
+        f.write("name: intel-gpu-ai-skills-agent\n")
+        f.write("description: Router agent exposing Intel GPU AI skill packs ")
+        f.write("for running, benchmarking, and profiling Hugging Face ")
+        f.write("models, and migrating workloads from CUDA on Intel GPUs.\n")
+        f.write("---\n\n")
         f.write("<skills>\n\n")
         f.write("You have additional SKILLs documented in directories ")
         f.write('containing a "SKILL.md" file.\n\n')


### PR DESCRIPTION
## What changed and why

Fixes a Gemini CLI extension install error caused by agents/AGENTS.md lacking YAML frontmatter:
```bash
[ExtensionManager] Error loading agent from intel-gpu-ai-skills: Failed to load agent from .../agents/AGENTS.md: Invalid agent definition: Missing mandatory YAML frontmatter. Agent Markdown files MUST start with YAML frontmatter enclosed in triple-dashes "---" (e.g., ---\nname: my-agent\n---).
```
Gemini CLI treats every file under an extension's `agents/` directory as a formal agent definition and requires `name`/`description` frontmatter. `agents/AGENTS.md` is generated by `scripts/generate_agents.py` as a plain skills-index body with no frontmatter, so every `gemini extensions install` emits this error even though the extension still installs and the skills still work.

### Changes

- **`scripts/generate_agents.py`**: now writes a `---`-delimited YAML frontmatter block (`name: intel-gpu-ai-skills-agent` +
  `description: ...`) at the top of the generated `agents/AGENTS.md`, before the `<skills>` body, so the file satisfies Gemini CLI's agent-definition requirement on every regeneration instead of only when hand-edited.
- **`agents/AGENTS.md`**: regenerated via `python3 scripts/generate_agents.py` to include the new frontmatter block; skills index content is unchanged.
- **`README.md`**: added a note under the Gemini CLI install instructions covering the `gemini extensions list` / `uninstall` / manual cleanup steps needed before reinstalling.

### Testing

- Ran `bash tests/static.sh` to confirm JSON manifests, SKILL.md frontmatter, and the `agents/AGENTS.md` generator-sync check all still pass with the new frontmatter block.
- Reproduced the original error with `gemini extensions install . --consent`, applied the fix, uninstalled stale `intel-model-skillpack` / `intel-gpu-ai-skills` extensions per the new README steps, and confirmed a clean install with no `ExtensionManager` error.

## Type of change

- [ ] New skill
- [ ] Fix to an existing skill
- [ ] Performance or accuracy improvement (include benchmark data below)
- [x] Docs or tooling

## Validation

- [x] `bash scripts/check-skills.sh` passes locally
- [x] `python3 scripts/generate_agents.py` was run after any `SKILL.md`
      frontmatter change (or the pre-commit hook handled it)
- [ ] For skill behavior changes, the relevant acceptance layer in
      `HOW_TO_TEST.md` was run on real hardware, or the reason it was not
      is explained above
- [x] Every commit is signed off (`git commit -s`), per the Developer
      Certificate of Origin in CONTRIBUTING.md


