### PR TITLE
fix(xpu-system-setup): check driver binding across all PCI domains

### DIFF
--- a/plugins/intel-gpu-ai-skills/skills/xpu-system-setup/scripts/check_battlemage_prerequisites.sh
+++ b/plugins/intel-gpu-ai-skills/skills/xpu-system-setup/scripts/check_battlemage_prerequisites.sh
@@ -118,7 +118,7 @@ fi
 
 # Match [8086:e211] or [8086:e223] exactly — avoids false-positives on other IDs
 # shellcheck disable=SC2046
-BMG_BDFS=$(lspci -d 8086: -nn 2>/dev/null \
+BMG_BDFS=$(lspci -D -d 8086: -nn 2>/dev/null \
     | grep -E '\[8086:e2(11|23)\]' \
     | awk '{print $1}' || true)
 

--- a/plugins/intel-gpu-ai-skills/skills/xpu-system-setup/scripts/check_battlemage_prerequisites.sh
+++ b/plugins/intel-gpu-ai-skills/skills/xpu-system-setup/scripts/check_battlemage_prerequisites.sh
@@ -171,7 +171,7 @@ LAYER2_OK=true
 BOUND_COUNT=0
 # shellcheck disable=SC2086
 for BDF in $BMG_BDFS; do
-    DRIVER=$(readlink "/sys/bus/pci/devices/0000:$BDF/driver" 2>/dev/null \
+    DRIVER=$(readlink "/sys/bus/pci/devices/$BDF/driver" 2>/dev/null \
         | xargs basename 2>/dev/null || echo "none")
     case "$DRIVER" in
         xe)


### PR DESCRIPTION
What changed and why
--------------------

Fixes a false positive in the Battlemage (Arc Pro B60/B70) prerequisites check.

`check_battlemage_prerequisites.sh` prepended a hardcoded `0000:` to the PCI BDF when reading the sysfs driver symlink:

    DRIVER=

But `lspci`'s first column already contains the full domain (e.g. `0001:1a:00.0`). On hosts where GPUs sit outside domain 0 — SR-IOV / virtualized multi-domain setups that expose GPUs under `0001:` — the path became `/sys/bus/pci/devices/0000:0001:1a:00.0/driver`, `readlink` resolved to nothing, and every GPU was misreported as "no driver bound". The script then wrongly recommended an OEM-kernel upgrade even though the `xe` driver was healthy.

Using `$BDF` directly makes the driver check work regardless of PCI domain:

    DRIVER=

No other behavior changes.

Type of change
--------------

-   New skill
-   **Fix to an existing skill**
-   Performance or accuracy improvement (include benchmark data below)
-   Docs or tooling

Validation
----------

-   `bash scripts/check-skills.sh` — static gate, routing, and secure-config suites all pass (22/22 secure-config, 11/11 routing). The only failure observed on this Windows checkout is a pre-existing `agents/AGENTS.md` drift caused by the generator emitting `\\` path separators under `core.autocrlf`; this is a Windows-local artifact, does not affect the Linux CI gate (forward slashes), and is unrelated to this change.
-   `python3 scripts/generate_agents.py` — n/a, no `SKILL.md` touched.
-   Acceptance on real hardware: ran the updated `check_battlemage_prerequisites.sh` on an 8x Intel Arc Pro B70 host whose GPUs are split across PCI domains `0000:` and `0001:`. All 8 GPUs now report `[PASS] GPU <BDF> bound to xe driver` and the script finishes with `[PASS] All prerequisites met - GPU is operational` (clinfo: 2 platform(s), xpu-smi 2.1.0, runtime 26.27). Before the fix the same host reported 8 FAILs.
-   Every commit is signed off (`git commit -s`), per the Developer Certificate of Origin in CONTRIBUTING.md.