### PR TITLE
fix: point the vLLM doc links at pages that still exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For deeper testing — install round-trip, per-skill acceptance, end-to-end smok
 - [vllm-project/vllm-skills](https://github.com/vllm-project/vllm-skills) — NVIDIA equivalents
 - [huggingface/skills](https://github.com/huggingface/skills) — Hub workflows
 - [PyTorch XPU getting started](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html)
-- [vLLM XPU installation](https://docs.vllm.ai/en/latest/getting_started/xpu-installation.html)
+- [vLLM XPU installation](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/?device=xpu)
 
 ## License
 

--- a/plugins/intel-gpu-ai-skills/skills/vllm-xpu-bench/SKILL.md
+++ b/plugins/intel-gpu-ai-skills/skills/vllm-xpu-bench/SKILL.md
@@ -323,4 +323,4 @@ Save a baseline JSON, diff against it on upgrades.
 ## References
 
 - `references/sweep-and-compare.md` — concurrency sweep, quant benches, run-vs-run diff
-- vLLM bench docs: <https://docs.vllm.ai/en/latest/contributing/profiling/profiling_index.html#offline-batched-inference-benchmarks>
+- vLLM bench docs: <https://docs.vllm.ai/en/latest/benchmarking/cli/>

--- a/plugins/intel-gpu-ai-skills/skills/vllm-xpu-profile/SKILL.md
+++ b/plugins/intel-gpu-ai-skills/skills/vllm-xpu-profile/SKILL.md
@@ -180,5 +180,5 @@ docker run --rm \
 
 ## References
 
-- vLLM profiling guide: <https://docs.vllm.ai/en/latest/contributing/profiling/profiling_index.html>
+- vLLM profiling guide: <https://docs.vllm.ai/en/latest/contributing/profiling/>
 - Perfetto trace viewer: <https://ui.perfetto.dev>

--- a/plugins/intel-gpu-ai-skills/skills/vllm-xpu-run/SKILL.md
+++ b/plugins/intel-gpu-ai-skills/skills/vllm-xpu-run/SKILL.md
@@ -225,6 +225,6 @@ while the server reports ready means the model loaded on CPU.
 - `references/multi-gpu-and-tuning.md` — TP, tuning, spec-decode, legacy envs
 - `references/remote-deploy.md` — serve + verify on a remote Intel GPU host over ssh
 - Image source: <https://hub.docker.com/r/vllm/vllm-openai-xpu>
-- vLLM XPU installation: <https://docs.vllm.ai/en/latest/getting_started/xpu-installation.html>
+- vLLM XPU installation: <https://docs.vllm.ai/en/latest/getting_started/installation/gpu/?device=xpu>
 - vLLM Arc Pro B-series blog: <https://blog.vllm.ai/2025/11/11/intel-arc-pro-b.html>
 - vLLM #38064 (W4A8 fall-through): <https://github.com/vllm-project/vllm/issues/38064>


### PR DESCRIPTION
## What changed and why

docs.vllm.ai dropped the `.html` URL scheme and reorganised two sections. All four links
this repository carries to it are stale — one is a hard 404, and the other three are worse,
because Read-the-Docs fuzzy-redirects them to a parent page, so they answer **200** while
sending the reader somewhere they did not ask for.

| file | old link | what it actually does today | new link |
|---|---|---|---|
| `README.md`, `vllm-xpu-run/SKILL.md` | `getting_started/xpu-installation.html` | 302 → `getting_started/xpu-installation/` → **404** | `getting_started/installation/gpu/?device=xpu` |
| `vllm-xpu-profile/SKILL.md` | `contributing/profiling/profiling_index.html` | 200, but lands on `contributing/` — the contributing index, not the profiling guide | `contributing/profiling/` |
| `vllm-xpu-bench/SKILL.md` | `…profiling_index.html#offline-batched-inference-benchmarks` | 200 at `contributing/`, and the anchor no longer exists anywhere on the site | `benchmarking/cli/` |

Notes on two of the choices:

- **XPU install.** There is no standalone XPU install page any more — `installation/gpu/xpu.html`
  404s. XPU is a tab on the shared GPU page, which `?device=xpu` selects.
- **Bench docs.** Benchmarking moved out of `contributing/` into its own top-level section
  while this link was pointing into it. `benchmarking/cli/` ("Benchmark CLI") is the page
  documenting the `vllm bench serve` / `throughput` / `latency` / `sweep` subcommands this
  skill actually runs, which is what the old anchor was there for.

Each replacement was fetched and read rather than inferred from a redirect: all return 200
at their final URL, and the two named pages carry the content the link text promises.

The three 200-with-wrong-destination cases are the reason this went unnoticed — no
status-code link checker can see them, and this repository's CI does not check links at
all. Downstream, `intel/skills` imports these three skills and its link check caught the
one real 404 today; the fix has to land here first, because an edited import stops matching
its pin.

## Type of change

- [ ] New skill
- [x] Fix to an existing skill
- [ ] Performance or accuracy improvement (include benchmark data below)
- [x] Docs or tooling

## Validation

- [x] `bash scripts/check-skills.sh` passes locally
- [x] `python3 scripts/generate_agents.py` was run after any `SKILL.md` frontmatter change (or the pre-commit hook handled it) — *no frontmatter changed; only reference-list URLs*
- [x] For skill behavior changes, the relevant acceptance layer in `HOW_TO_TEST.md` was run on real hardware, or the reason it was not is explained above — *no behavior change: four reference URLs, no commands, flags, or guidance touched*
- [x] Every commit is signed off (`git commit -s`), per the Developer Certificate of Origin in CONTRIBUTING.md
